### PR TITLE
🐛 修复 `Behav` 的 `banGroupMember` 方法返回事件属性缺失问题

### DIFF
--- a/src/adapter/behav.ts
+++ b/src/adapter/behav.ts
@@ -308,6 +308,7 @@ export class Behav {
       user_id: userId,
       operator_id: operatorId,
       chat_type: 'group',
+      duration,
       sender_id: operatorId,
       receiver_id: groupId,
     }


### PR DESCRIPTION
<!--
感谢您对本项目的贡献！
请确保您已阅读过本项目的贡献指南。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
为避免浪费时间，最好先打开相关议题，等待批准后再处理。
-->

- [x] 错误修复
- [ ] 新功能 
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:


### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有


### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

补充缺失字段 `duration`

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

返回事件中缺少了禁言持续时间字段 `duration`

### 其他信息
<!-- 任何您觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复