### PR TITLE
🐛 修复 OneBot v12 使用 data 方式上传文件失败的问题

### DIFF
--- a/src-tauri/src/command.rs
+++ b/src-tauri/src/command.rs
@@ -53,9 +53,11 @@ pub fn open_devtools(window: Window) {
     window.open_devtools();
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub enum OBFile {
+    #[serde(rename = "str")]
     Str(String),
+    #[serde(rename = "binary")]
     Binary(Vec<u8>),
 }
 

--- a/src/adapter/onebot/v12/action.ts
+++ b/src/adapter/onebot/v12/action.ts
@@ -245,6 +245,10 @@ const actionStrategy: ActionStrategy<ActionResponse> = {
           return response(0, { file_id: file.id })
         }
       }
+      if (fileInfo.type === 'data') {
+        fileInfo.data =
+          fileInfo.data instanceof Uint8Array ? { binary: fileInfo.data } : { str: fileInfo.data as string }
+      }
       const { size, sha256 } = await invoke<{ size: number; sha256: string }>('upload_file', { file: fileInfo })
       const fileId = getUUID()
       await db.files.add({ id: fileId, name: fileInfo.name, sha256, size })
@@ -342,7 +346,9 @@ type FileURL<T extends FileType = never> = FileInfo<T> & { url: string; headers?
 
 type FilePath<T extends FileType = never> = FileInfo<T> & { path: string }
 
-type FileData<T extends FileType = never> = FileInfo<T> & { data: string | Uint8Array }
+type FileData<T extends FileType = never> = FileInfo<T> & {
+  data: string | Uint8Array | { str?: string; binary?: Uint8Array }
+}
 
 interface UploadFilePrepare {
   stage: 'prepare'

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -6,8 +6,8 @@ import { db } from '@/database'
 import { getUUID } from './utils'
 
 interface FileSource {
-  Str?: string
-  Binary?: number[]
+  str?: string
+  binary?: number[]
 }
 
 async function getSHA256(buffer: ArrayBuffer): Promise<string> {
@@ -39,9 +39,9 @@ export async function createFileCache(
         url: await getFile(GetType.URL, cacheFile.id),
       }
     }
-    fileSource.Binary = Array.from(new Uint8Array(buffer))
+    fileSource.binary = Array.from(new Uint8Array(buffer))
   } else {
-    fileSource.Str = file
+    fileSource.str = file
   }
   const fileId = getUUID()
   const { size, sha256 } = await invoke<{ size: number; sha256: string }>('create_cache_file', {


### PR DESCRIPTION
<!--
感谢您对本项目的贡献！
请确保您已阅读过本项目的贡献指南。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
为避免浪费时间，最好先打开相关议题，等待批准后再处理。
-->

- [x] 错误修复
- [ ] 新功能 
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:


### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有


### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

将 data 参数转换为后端使用的枚举类型

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

使用 data 方式上传文件时，返回了参数错误的响应

### 其他信息
<!-- 任何您觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复