### PR TITLE
🐛 修复 OneBot 12 中 platform 不统一的问题

### DIFF
--- a/src/adapter/onebot/v12/bot.ts
+++ b/src/adapter/onebot/v12/bot.ts
@@ -62,7 +62,7 @@ export class OneBotV12 extends Adapter {
         bots: [
           {
             self: {
-              platform: 'qq',
+              platform: 'matcha',
               user_id: this.status.assignBot,
             },
             online: true,


### PR DESCRIPTION
ob12 中，应该所有的 platform 都为 matcha。