### PR TITLE
🐛 修复群禁言通知没有区分开关状态的问题

### DIFF
--- a/src/components/ChatNotice.vue
+++ b/src/components/ChatNotice.vue
@@ -18,6 +18,7 @@ import type {
   GroupMemberCardNoticeScene,
   GroupEssenceNoticeScene,
   GroupHongbaoLuckyNoticeScene,
+  GroupWholeBanNoticeScene,
 } from '@/adapter/scene'
 import type { Notice } from '@/stores/chat'
 
@@ -68,7 +69,9 @@ const noticeStrategy = {
     const time = Math.ceil(duration / 60)
     return time > 0 ? `{target} 被{sender}禁言${time}分钟` : '{target} 被{sender}解除禁言'
   },
-  'group_whole_ban': () => '{sender}开启/关闭了全员禁言',
+  'group_whole_ban': (scene: GroupWholeBanNoticeScene) => {
+    return `{sender}${scene.sub_type === 'open' ? '开启' : '关闭'}了全员禁言`
+  },
   'group_anonymous': () => '管理员已允许群内匿名聊天',
   'group_name': () => '{sender}修改了群名',
   'group_member_card': (scene: GroupMemberCardNoticeScene, context: Context) => {


### PR DESCRIPTION
<!--
感谢您对本项目的贡献！
在创建 PR 之前，请确保您已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

对开关状态的群禁言通知进行了区分

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->



### 其他信息
<!-- 任何您觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [ ] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
